### PR TITLE
Bug/avoid additional purchase more than 12 places

### DIFF
--- a/server.py
+++ b/server.py
@@ -14,7 +14,21 @@ def loadCompetitions():
         listOfCompetitions = json.load(comps)['competitions']
         return listOfCompetitions
 
-competitions = loadCompetitions()
+def addAlreadyBoughtPlaces(competitions):
+    print('ici')
+    for competition in competitions:
+        competition['alreadyBoughtPlaces'] = {}
+    return competitions
+
+def backUpBoughtPlaces(competition, club, boughtPlaces):
+    if competition['alreadyBoughtPlaces'].get(club['email']):
+        competition['alreadyBoughtPlaces'][club['email']] = int(competition['alreadyBoughtPlaces'][club['email']]) + int(boughtPlaces)
+        return competition
+    competition['alreadyBoughtPlaces'][club['email']] = int(boughtPlaces)
+    return competition
+
+loadedCompetitions = loadCompetitions()
+competitions = addAlreadyBoughtPlaces(loadedCompetitions)
 clubs = loadClubs()
 
 def create_app(config):
@@ -65,12 +79,18 @@ def create_app(config):
         if placesRequired > 12:
             flash('You can\'t purchase more than 12 places.')
             return render_template('booking.html', club=club, competition=competition)
+        if competition['alreadyBoughtPlaces'].get(club['email']):
+            alreadyBoughtPlaces = competition['alreadyBoughtPlaces'].get(club['email'])
+            if placesRequired + int(alreadyBoughtPlaces) > 12:
+                flash(f'You can\'t purchase more than 12 places and you have already bought {alreadyBoughtPlaces}')
+                return render_template('booking.html', club=club, competition=competition)
         if placesRequired > int(competition['numberOfPlaces']):
             flash('You can\'t purchase more than available places.')
             return render_template('booking.html', club=club, competition=competition)
         competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+        competition = backUpBoughtPlaces(competition, club, placesRequired)
         club['points'] = int(club['points']) - placesRequired
-        flash('Great-booking complete!')
+        flash(f'Great-booking complete! You just bought {placesRequired} places.')
         return render_template('welcome.html', club=club, competitions=competitions)
 
     @app.route('/clubs')

--- a/server.py
+++ b/server.py
@@ -15,7 +15,6 @@ def loadCompetitions():
         return listOfCompetitions
 
 def addAlreadyBoughtPlaces(competitions):
-    print('ici')
     for competition in competitions:
         competition['alreadyBoughtPlaces'] = {}
     return competitions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,12 @@ def test_competitions(mocker):
             "date": "1900-03-27 10:00:00",
             "numberOfPlaces": "15",
             "alreadyBoughtPlaces": {},
+        },
+        {
+            "name": "name3",
+            "date": "2023-03-27 10:00:00",
+            "numberOfPlaces": "15",
+            "alreadyBoughtPlaces": {"test2@test.co": 11},
         }
     ]
     mocker.patch('server.competitions', competitions)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,17 +31,20 @@ def test_competitions(mocker):
         {
             "name": "name",
             "date": "2030-03-27 10:00:00",
-            "numberOfPlaces": "5"
+            "numberOfPlaces": "5",
+            "alreadyBoughtPlaces": {},
         },
         {
             "name": "name2",
             "date": "2030-03-27 10:00:00",
-            "numberOfPlaces": "15"
+            "numberOfPlaces": "15",
+            "alreadyBoughtPlaces": {},
         },
         {
             "name": "past event",
             "date": "1900-03-27 10:00:00",
-            "numberOfPlaces": "15"
+            "numberOfPlaces": "15",
+            "alreadyBoughtPlaces": {},
         }
     ]
     mocker.patch('server.competitions', competitions)

--- a/tests/functionnal_tests/test_server.py
+++ b/tests/functionnal_tests/test_server.py
@@ -56,7 +56,7 @@ class MyTest(LiveServerTestCase):
         places.send_keys('1')
         places.send_keys(Keys.ENTER)
         element = chrome_driver.find_element(By.TAG_NAME, 'li')
-        assert element.text == 'Great-booking complete!'
+        assert 'Great-booking complete!' in element.text
 
     def test_login_book_places_no_success_not_enough_club_points(self):
         self.login('test@test.co')
@@ -102,6 +102,31 @@ class MyTest(LiveServerTestCase):
         places.send_keys(Keys.ENTER)
         element = chrome_driver.find_element(By.TAG_NAME, 'li')
         assert element.text == 'You can\'t purchase more than available places.'
+    
+    def test_login_book_places_success_book_places_no_success_more_than_12_places_in_total(self):
+        self.login('test2@test.co')
+        element = chrome_driver.find_element(By.TAG_NAME, 'h2')
+        assert element.text == 'Welcome, test2@test.co'
+
+        book_link = chrome_driver.find_elements(By.LINK_TEXT, 'Book Places')
+        book_link[1].click()
+        element = chrome_driver.find_element(By.TAG_NAME, 'h2')
+        assert element.text == 'name2'
+        places = chrome_driver.find_element(By.NAME, 'places')
+        places.send_keys('3')
+        places.send_keys(Keys.ENTER)
+        element = chrome_driver.find_element(By.TAG_NAME, 'li')
+        assert 'Great-booking complete!' in element.text
+
+        book_link = chrome_driver.find_elements(By.LINK_TEXT, 'Book Places')
+        book_link[1].click()
+        element = chrome_driver.find_element(By.TAG_NAME, 'h2')
+        assert element.text == 'name2'
+        places = chrome_driver.find_element(By.NAME, 'places')
+        places.send_keys('10')
+        places.send_keys(Keys.ENTER)
+        element = chrome_driver.find_element(By.TAG_NAME, 'li')
+        assert 'You can\'t purchase more than 12 places and you have already bought' in element.text
     
     def test_login_view_club_logout_view_club(self):
         self.login('test@test.co')

--- a/tests/unit_tests/test_server.py
+++ b/tests/unit_tests/test_server.py
@@ -87,8 +87,7 @@ def test_logout_should_return_code_redirect(client):
     assert 'target URL: <a href="/">/</a>' in response.data.decode()
 
 
-class TestDisplayBoard:
-    def test_should_return_code_ok_no_login(self, client):
-        response = client.get('/clubs')
-        assert response.status_code == 200
-        assert '<th>Clubs</th>' in response.data.decode()
+def test_should_return_code_ok_no_login(self, client):
+    response = client.get('/clubs')
+    assert response.status_code == 200
+    assert '<th>Clubs</th>' in response.data.decode()

--- a/tests/unit_tests/test_server.py
+++ b/tests/unit_tests/test_server.py
@@ -1,4 +1,4 @@
-import pytest
+from server import addAlreadyBoughtPlaces, backUpBoughtPlaces
 
 
 def test_index_should_return_code_ok(client):
@@ -87,7 +87,50 @@ def test_logout_should_return_code_redirect(client):
     assert 'target URL: <a href="/">/</a>' in response.data.decode()
 
 
-def test_should_return_code_ok_no_login(self, client):
+def test_should_return_code_ok_no_login(client):
     response = client.get('/clubs')
     assert response.status_code == 200
     assert '<th>Clubs</th>' in response.data.decode()
+
+def test_should_add_additional_key_to_competitions():
+    tested_competition = [
+        {
+            "name": "name",
+            "date": "2030-03-27 10:00:00",
+            "numberOfPlaces": "1",
+        }
+    ]
+    expected_results = [
+        {
+            "name": "name",
+            "date": "2030-03-27 10:00:00",
+            "numberOfPlaces": "1",
+            "alreadyBoughtPlaces": {},
+        }
+    ]
+    assert addAlreadyBoughtPlaces(tested_competition) == expected_results
+
+class TestBackUpBoughtPlaces:
+    def setup_method(self):
+        self.competition = {
+            "name": "name",
+            "date": "2030-03-27 10:00:00",
+            "numberOfPlaces": "10",
+            "alreadyBoughtPlaces": {},
+        }
+        self.club = {
+            "name": "name",
+            "email": "test@test.co",
+            "points": "6",
+        }
+
+    def test_should_add_club_history_to_competition_purchased(self):
+        expected_competition_value = {"test@test.co": 2}
+        testing_back_up = backUpBoughtPlaces(self.competition, self.club, 2)
+        assert testing_back_up["alreadyBoughtPlaces"]  == expected_competition_value
+    
+    def test_should_add_points_in_back_up(self):
+        self.competition["alreadyBoughtPlaces"] = {"test@test.co": 2}
+        expected_competition_value = {"test@test.co": 6}
+        testing_back_up = backUpBoughtPlaces(self.competition, self.club, 4)
+        assert testing_back_up["alreadyBoughtPlaces"] == expected_competition_value

--- a/tests/unit_tests/test_server.py
+++ b/tests/unit_tests/test_server.py
@@ -40,6 +40,11 @@ class TestPurchasePlaces:
         assert response.status_code == 200
         assert "You can&#39;t purchase more than 12 places." in response.data.decode()
     
+    def test_should_not_purchase_more_than_12_places_in_total(self, client):
+        response = client.post('/purchasePlaces', data={'club': 'name2', 'competition': 'name3', 'places': '2'})
+        assert response.status_code == 200
+        assert "You can&#39;t purchase more than 12 places and you have already bought" in response.data.decode()
+    
     def test_should_not_purchase_more_than_available_places(self, client):
         response = client.post('/purchasePlaces', data={'club': 'name2', 'competition': 'name', 'places': '6'})
         assert response.status_code == 200


### PR DESCRIPTION
Bug relative to issue #4 

User were allowed to purchase 6 places to a competition, go back to the main menu and then purchase 7 places. That means they were allowed to buy more than 12 places with several purchases. 

Now, each competition have an history of each club purchased. Clubs can no more buy 12 places with several purchases.
Unit tests and functional tests have been added to test every new functionality.
